### PR TITLE
Add datetime import to FastAPI app

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,9 +1,10 @@
 # api/app/main.py
+from datetime import datetime
 import logging
 from fastapi import FastAPI, Request, status
-from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from app.core.config import settings
 from app.core.db import init_db


### PR DESCRIPTION
## Summary
- import `datetime` in `main.py`
- keep alphabetical ordering of imports

## Testing
- `pytest -q` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_683fb0b3ef94833392487b71a3e80be6