### PR TITLE
Add mission pages and REST context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv/
 pip-selfcheck.json
 *.egg-info/
 .env
+!ui_web/.env
 
 # Node / React
 node_modules/

--- a/ui_web/.env
+++ b/ui_web/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/ui_web/src/App.jsx
+++ b/ui_web/src/App.jsx
@@ -1,9 +1,5 @@
 import { Routes, Route, NavLink } from 'react-router-dom';
-import Dashboard from './pages/Dashboard';
-import Settings from './pages/Settings';
-import Users from './pages/Users';
-
-import Login from './pages/Login';
+import { Dashboard, Settings, Users, Maps, Points, Missions, Login } from './pages';
 import ProtectedRoute from './ProtectedRoute';
 import { useAuth } from './AuthContext';
 
@@ -35,15 +31,38 @@ export default function App() {
         </nav>
       </header>
 
-      <main className="flex-1 container mx-auto p-4">
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
-          <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
-          <Route path="/users" element={<ProtectedRoute><Users /></ProtectedRoute>} />
-
-        </Routes>
-      </main>
+      <div className="flex flex-1">
+        <aside className="w-48 bg-gray-100 p-4">
+          <ul className="space-y-2">
+            <li>
+              <NavLink to="/maps" className={active}>
+                Mapas
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/points" className={active}>
+                Puntos
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/missions" className={active}>
+                Misiones
+              </NavLink>
+            </li>
+          </ul>
+        </aside>
+        <main className="flex-1 container mx-auto p-4">
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+            <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
+            <Route path="/users" element={<ProtectedRoute><Users /></ProtectedRoute>} />
+            <Route path="/maps" element={<ProtectedRoute><Maps /></ProtectedRoute>} />
+            <Route path="/points" element={<ProtectedRoute><Points /></ProtectedRoute>} />
+            <Route path="/missions" element={<ProtectedRoute><Missions /></ProtectedRoute>} />
+          </Routes>
+        </main>
+      </div>
     </div>
   );
 }

--- a/ui_web/src/context/DataContext.jsx
+++ b/ui_web/src/context/DataContext.jsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState, useEffect } from "react";
+import { MapsAPI, PointsAPI, MissionsAPI } from "../services/api";
+
+const Ctx = createContext(null);
+export const useData = () => useContext(Ctx);
+
+export function DataProvider({ children }) {
+  const [maps, setMaps] = useState([]);
+  const [selectedMap, setSelectedMap] = useState(null);
+  const [points, setPoints] = useState([]);
+  const [missions, setMissions] = useState([]);
+
+  useEffect(() => {
+    MapsAPI.list().then(setMaps);
+  }, []);
+
+  useEffect(() => {
+    if (!selectedMap) return;
+    PointsAPI.list(selectedMap).then(setPoints);
+    MissionsAPI.list(selectedMap).then(setMissions);
+  }, [selectedMap]);
+
+  return (
+    <Ctx.Provider
+      value={{
+        maps,
+        setMaps,
+        selectedMap,
+        setSelectedMap,
+        points,
+        setPoints,
+        missions,
+        setMissions
+      }}
+    >
+      {children}
+    </Ctx.Provider>
+  );
+}

--- a/ui_web/src/main.jsx
+++ b/ui_web/src/main.jsx
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './AuthContext';
+import { DataProvider } from './context/DataContext';
 import './styles.css'; // Tailwind entry (crear en src/ o usar index.css)
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </BrowserRouter>
+    <DataProvider>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </DataProvider>
   </React.StrictMode>
 );

--- a/ui_web/src/pages/Maps.jsx
+++ b/ui_web/src/pages/Maps.jsx
@@ -1,0 +1,54 @@
+import { useRef } from "react";
+import { useData } from "../context/DataContext";
+import { MapsAPI } from "../services/api";
+
+export default function Maps() {
+  const { maps, setMaps, setSelectedMap } = useData();
+  const nameRef = useRef();
+  const pgmRef = useRef();
+  const yamlRef = useRef();
+
+  const upload = async e => {
+    e.preventDefault();
+    await MapsAPI.upload(
+      nameRef.current.value,
+      pgmRef.current.files[0],
+      yamlRef.current.files[0]
+    );
+    setMaps(await MapsAPI.list());
+    e.target.reset();
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Mapas</h2>
+      <form onSubmit={upload} className="flex gap-2 flex-wrap">
+        <input ref={nameRef} placeholder="Nombre" required className="input" />
+        <input ref={pgmRef} type="file" accept=".pgm" required />
+        <input ref={yamlRef} type="file" accept=".yaml" required />
+        <button className="btn">Subir</button>
+      </form>
+      <ul className="space-y-1">
+        {maps.map(m => (
+          <li key={m._id} className="flex justify-between">
+            <span
+              onClick={() => setSelectedMap(m._id)}
+              className="cursor-pointer hover:underline"
+            >
+              {m.name}
+            </span>
+            <button
+              onClick={async () => {
+                await MapsAPI.delete(m.name);
+                setMaps(await MapsAPI.list());
+              }}
+              className="text-red-600"
+            >
+              🗑
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ui_web/src/pages/Missions.jsx
+++ b/ui_web/src/pages/Missions.jsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useData } from "../context/DataContext";
+import { MissionsAPI } from "../services/api";
+
+export default function Missions() {
+  const { selectedMap, points, missions, setMissions } = useData();
+  const [form, setForm] = useState({ name: "", loop: false, sequence: [] });
+
+  if (!selectedMap) return <p className="p-4">Selecciona un mapa.</p>;
+
+  const toggleSeq = id =>
+    setForm(f => ({
+      ...f,
+      sequence: f.sequence.includes(id)
+        ? f.sequence.filter(x => x !== id)
+        : [...f.sequence, id]
+    }));
+
+  const save = async e => {
+    e.preventDefault();
+    await MissionsAPI.create({ ...form, map_id: selectedMap });
+    setMissions(await MissionsAPI.list(selectedMap));
+    setForm({ name: "", loop: false, sequence: [] });
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Misiones</h2>
+      <form onSubmit={save} className="space-y-2">
+        <input
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+          placeholder="Nombre"
+          required
+          className="input"
+        />
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={form.loop}
+            onChange={e => setForm({ ...form, loop: e.target.checked })}
+          />
+          loop
+        </label>
+        <fieldset className="border p-2">
+          <legend>Seleccionar puntos</legend>
+          {points.map(p => (
+            <label key={p._id} className="block">
+              <input
+                type="checkbox"
+                checked={form.sequence.includes(p._id)}
+                onChange={() => toggleSeq(p._id)}
+              />
+              {` ${p.name}`}
+            </label>
+          ))}
+        </fieldset>
+        <button className="btn">Guardar misión</button>
+      </form>
+      <ul className="space-y-1">
+        {missions.map(m => (
+          <li key={m._id} className="flex justify-between">
+            <span>{m.name}</span>
+            <button
+              onClick={async () => {
+                await MissionsAPI.delete(m._id);
+                setMissions(await MissionsAPI.list(selectedMap));
+              }}
+              className="text-red-600"
+            >
+              🗑
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ui_web/src/pages/Points.jsx
+++ b/ui_web/src/pages/Points.jsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useData } from "../context/DataContext";
+import { PointsAPI } from "../services/api";
+
+export default function Points() {
+  const { selectedMap, points, setPoints } = useData();
+  const emptyPose = { x: 0, y: 0, z: 0, q1: 0, q2: 0, q3: 0, q4: 1 };
+  const [form, setForm] = useState({ name: "", type: "way", target: emptyPose });
+
+  if (!selectedMap) return <p className="p-4">Selecciona un mapa.</p>;
+
+  const onChange = e => setForm({ ...form, [e.target.name]: e.target.value });
+  const onPoseChange = e =>
+    setForm({ ...form, target: { ...form.target, [e.target.name]: parseFloat(e.target.value) } });
+
+  const save = async e => {
+    e.preventDefault();
+    await PointsAPI.create({ ...form, map_id: selectedMap });
+    setPoints(await PointsAPI.list(selectedMap));
+    setForm({ name: "", type: "way", target: emptyPose });
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Puntos</h2>
+      <form onSubmit={save} className="grid gap-2 grid-cols-4">
+        <input
+          name="name"
+          value={form.name}
+          onChange={onChange}
+          placeholder="Nombre"
+          required
+          className="input col-span-2"
+        />
+        <select name="type" value={form.type} onChange={onChange} className="input">
+          <option value="way">way</option>
+          <option value="dock">dock</option>
+          <option value="station">station</option>
+        </select>
+        {[
+          "x",
+          "y",
+          "z",
+          "q1",
+          "q2",
+          "q3",
+          "q4"
+        ].map(k => (
+          <input
+            key={k}
+            name={k}
+            value={form.target[k]}
+            onChange={onPoseChange}
+            step="0.01"
+            className="input"
+            placeholder={k}
+          />
+        ))}
+        <button className="btn col-span-4">Guardar</button>
+      </form>
+      <ul className="space-y-1">
+        {points.map(p => (
+          <li key={p._id} className="flex justify-between">
+            <span>{p.name}</span>
+            <button
+              onClick={async () => {
+                await PointsAPI.delete(p._id);
+                setPoints(await PointsAPI.list(selectedMap));
+              }}
+              className="text-red-600"
+            >
+              🗑
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ui_web/src/pages/index.js
+++ b/ui_web/src/pages/index.js
@@ -1,0 +1,7 @@
+export { default as Dashboard } from './Dashboard';
+export { default as Login } from './Login';
+export { default as Settings } from './Settings';
+export { default as Users } from './Users';
+export { default as Maps } from './Maps';
+export { default as Points } from './Points';
+export { default as Missions } from './Missions';

--- a/ui_web/src/services/api.js
+++ b/ui_web/src/services/api.js
@@ -1,0 +1,40 @@
+const BASE = import.meta.env.VITE_API_URL ?? "http://localhost:5000";
+
+async function req(method, url, body, isForm = false) {
+  const init = { method, headers: {} };
+  if (body) {
+    if (isForm) {
+      init.body = body;
+    } else {
+      init.body = JSON.stringify(body);
+      init.headers["Content-Type"] = "application/json";
+    }
+  }
+  const res = await fetch(BASE + url, init);
+  if (!res.ok) throw new Error(await res.text());
+  return res.status === 204 ? null : res.json();
+}
+
+export const MapsAPI = {
+  list: () => req("GET", "/maps"),
+  upload: (name, pgm, yaml) => {
+    const f = new FormData();
+    f.append("name", name);
+    f.append("pgm", pgm);
+    f.append("yaml", yaml);
+    return req("POST", "/maps", f, true);
+  },
+  delete: name => req("DELETE", `/maps/${name}`)
+};
+
+export const PointsAPI = {
+  list: mapId => req("GET", `/points${mapId ? `?map_id=${mapId}` : ""}`),
+  create: p => req("POST", "/points", p),
+  delete: id => req("DELETE", `/points/${id}`)
+};
+
+export const MissionsAPI = {
+  list: mapId => req("GET", `/missions${mapId ? `?map_id=${mapId}` : ""}`),
+  create: m => req("POST", "/missions", m),
+  delete: id => req("DELETE", `/missions/${id}`)
+};


### PR DESCRIPTION
## Summary
- implement REST wrapper for Maps, Points and Missions
- add DataContext provider for map-based state management
- create new pages for Maps, Points and Missions
- integrate sidebar navigation and routing
- add environment variable for API URL

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842e25225c88333b06a664d5db4061e