### PR TITLE
Add ROS orchestrator node

### DIFF
--- a/api/app/domain/maps/service.py
+++ b/api/app/domain/maps/service.py
@@ -72,7 +72,7 @@ async def activate_map(map_name: str) -> dict:
         await asyncio.wait_for(asyncio.to_thread(ros_client.run), timeout=5.0)
         logger.info(f"Conectado a ROSbridge en {settings.rosbridge_url}")
 
-        service = roslibpy.Service(ros_client, '/map_server/load_map', 'nav2_msgs/LoadMap')
+        service = roslibpy.Service(ros_client, '/ui/load_map', 'nav2_msgs/LoadMap')
         request = roslibpy.ServiceRequest({'map_url': f"/root/maps/{map_name}.yaml"})
 
         loop = asyncio.get_running_loop()

--- a/orchestrator/orchestrator/main.py
+++ b/orchestrator/orchestrator/main.py
@@ -1,0 +1,59 @@
+import rclpy
+from rclpy.lifecycle import LifecycleNode
+from lifecycle_msgs.msg import Transition
+from nav2_msgs.srv import LoadMap
+from std_srvs.srv import Empty
+from slam_toolbox_msgs.srv import LifecycleControl
+
+class Orchestrator(LifecycleNode):
+    def __init__(self):
+        super().__init__('ui_orchestrator')
+        self.create_service(Empty, 'ui/start_slam', self.start_slam)
+        self.create_service(Empty, 'ui/stop_slam', self.stop_slam)
+        self.create_service(LoadMap, 'ui/load_map', self.load_map)
+        self.create_service(Empty, 'ui/start_nav2', self.start_nav2)
+        self.create_service(Empty, 'ui/stop_nav2', self.stop_nav2)
+
+    def call_empty_service(self, service_name):
+        client = self.create_client(Empty, service_name)
+        if not client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().error(f'Service {service_name} unavailable')
+            return
+        request = Empty.Request()
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self, future)
+
+    def start_slam(self, request, response):
+        self.call_empty_service('/slam_toolbox/start')
+        return response
+
+    def stop_slam(self, request, response):
+        self.call_empty_service('/slam_toolbox/stop')
+        return response
+
+    def load_map(self, request, response):
+        client = self.create_client(LoadMap, '/map_server/load_map')
+        if not client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().error('Map server not available')
+            return response
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self, future)
+        return future.result()
+
+    def start_nav2(self, request, response):
+        self.call_empty_service('/lifecycle_manager_navigation/startup')
+        return response
+
+    def stop_nav2(self, request, response):
+        self.call_empty_service('/lifecycle_manager_navigation/shutdown')
+        return response
+
+def main():
+    rclpy.init()
+    node = Orchestrator()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/orchestrator/package.xml
+++ b/orchestrator/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>orchestrator</name>
+  <version>0.1.0</version>
+  <description>UI orchestrator node</description>
+  <maintainer email="user@example.com">user</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>rclpy</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>nav2_msgs</depend>
+  <depend>slam_toolbox_msgs</depend>
+  <exec_depend>setuptools</exec_depend>
+</package>

--- a/orchestrator/setup.py
+++ b/orchestrator/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+package_name = 'orchestrator'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[package_name],
+    install_requires=['rclpy'],
+    entry_points={
+        'console_scripts': [
+            'orchestrator = orchestrator.main:main',
+        ],
+    },
+)

--- a/turtlebot3-sim/Dockerfile
+++ b/turtlebot3-sim/Dockerfile
@@ -17,6 +17,12 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y ros-humble-slam-toolbox
 
+# Copiar y compilar paquete orchestrator
+COPY orchestrator /ros2_ws/src/orchestrator
+RUN . /opt/ros/humble/setup.sh && \
+    cd /ros2_ws && colcon build --packages-select orchestrator && \
+    rm -rf build log
+
 
 ENV TURTLEBOT3_MODEL=burger
 CMD ["/bin/bash"]

--- a/turtlebot3-sim/docker-compose.yml
+++ b/turtlebot3-sim/docker-compose.yml
@@ -28,16 +28,10 @@ services:
     command: >
       bash -c "
         source /opt/ros/humble/setup.bash &&
-        # Gazebo en background
+        source /ros2_ws/install/setup.bash &&
         ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py &
-
-        sleep 15 &&
-
         ros2 launch rosbridge_server rosbridge_websocket_launch.xml &
-
-        # SLAM async en /root/maps
-        ros2 launch slam_toolbox online_async_launch.py \
-          --ros-args -p use_sim_time:=true &
+        ros2 run orchestrator orchestrator
       "
 
   rviz:


### PR DESCRIPTION
## Summary
- add a ROS2 `orchestrator` package with lifecycle services to control SLAM and Nav2
- build orchestrator in the simulation Docker image
- launch orchestrator alongside rosbridge in the tb3 container
- update API service to call the new `/ui/load_map` service

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q` *(fails: ServerSelectionTimeoutError connecting to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_6846463cd0ec83339ecd035a35699a5b