### PR TITLE
Fix orchestrator build in docker

### DIFF
--- a/turtlebot3-sim/orchestrator/package.xml
+++ b/turtlebot3-sim/orchestrator/package.xml
@@ -13,4 +13,8 @@
   <depend>nav2_msgs</depend>
   <depend>slam_toolbox_msgs</depend>
   <exec_depend>setuptools</exec_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
 </package>


### PR DESCRIPTION
## Summary
- specify that orchestrator is an `ament_python` package to avoid cmake errors during docker build

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68487d4e57e08333a28d2ee03e62eb6a