### PR TITLE
Fix orchestrator build in docker

### DIFF
--- a/turtlebot3-sim/orchestrator/package.xml
+++ b/turtlebot3-sim/orchestrator/package.xml
@@ -13,4 +13,8 @@
   <depend>nav2_msgs</depend>
   <depend>slam_toolbox_msgs</depend>
   <exec_depend>setuptools</exec_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
 </package>

--- a/turtlebot3-sim/orchestrator/resource/orchestrator
+++ b/turtlebot3-sim/orchestrator/resource/orchestrator
@@ -1,0 +1,1 @@
+orchestrator

--- a/turtlebot3-sim/orchestrator/setup.py
+++ b/turtlebot3-sim/orchestrator/setup.py
@@ -6,6 +6,12 @@ setup(
     name=package_name,
     version='0.1.0',
     packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages', [
+            'resource/' + package_name
+        ]),
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['rclpy'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Summary
- specify that orchestrator is an `ament_python` package to avoid cmake errors during docker build
- add ament resource index entry so ROS can find the package

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68487d4e57e08333a28d2ee03e62eb6a