### PR TITLE
Fix nav2 lifecycle command for map server

### DIFF
--- a/turtlebot3-sim/orchestrator/orchestrator/main.py
+++ b/turtlebot3-sim/orchestrator/orchestrator/main.py
@@ -81,19 +81,12 @@ class Orchestrator(LifecycleNode):
         self.get_logger().info('Stopping SLAM Toolbox before loading map')
         self.call_empty(self.slam_stop_client, '/slam_toolbox/stop')
 
-        # Configure and activate the Map Server
-        self.get_logger().info('Configuring Map Server')
+        # Start up the Map Server lifecycle
+        self.get_logger().info('Starting Map Server')
         if not self.call_manage_lifecycle(
             self.map_lifecycle_client,
             '/lifecycle_manager_map_server/manage_nodes',
-            ManageLifecycleNodes.Request.CONFIGURE
-        ):
-            return response
-        self.get_logger().info('Activating Map Server')
-        if not self.call_manage_lifecycle(
-            self.map_lifecycle_client,
-            '/lifecycle_manager_map_server/manage_nodes',
-            ManageLifecycleNodes.Request.ACTIVATE
+            ManageLifecycleNodes.Request.STARTUP
         ):
             return response
 


### PR DESCRIPTION
## Summary
- handle map server lifecycle using `STARTUP` instead of nonexistent `CONFIGURE`/`ACTIVATE`

## Testing
- `pip install -r api/requirements.txt`
- `PYTHONPATH=api pytest api/tests -q` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_684c2868ab9883338a7718e2fd946876