### PR TITLE
Improve orchestrator wait and ROS connection

### DIFF
--- a/api/app/core/ros.py
+++ b/api/app/core/ros.py
@@ -1,0 +1,44 @@
+import roslibpy
+import logging
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+class RosClientManager:
+    def __init__(self):
+        self.client = None
+        self.is_connecting = False
+
+    def connect(self):
+        if self.client and self.client.is_connected:
+            logger.info("ROS client ya está conectado.")
+            return
+
+        if self.is_connecting:
+            logger.warning("Conexión ROS ya en progreso.")
+            return
+        try:
+            self.is_connecting = True
+            host = settings.rosbridge_url.split('//')[1].split(':')[0]
+            port = int(settings.rosbridge_url.split(':')[-1])
+            self.client = roslibpy.Ros(host=host, port=port)
+            self.client.run()
+            logger.info(f"Conectado a ROSBridge en {settings.rosbridge_url}")
+        except Exception as e:
+            logger.error(f"Fallo al conectar con ROSBridge: {e}", exc_info=True)
+            self.client = None
+        finally:
+            self.is_connecting = False
+
+    def disconnect(self):
+        if self.client and self.client.is_connected:
+            self.client.terminate()
+            logger.info("Conexión con ROSBridge terminada.")
+
+    def get_client(self):
+        if not self.client or not self.client.is_connected:
+            logger.error("Se solicitó el cliente ROS pero no está conectado.")
+            raise ConnectionError("No hay conexión con ROS.")
+        return self.client
+
+ros_manager = RosClientManager()


### PR DESCRIPTION
## Summary
- add global ROS client manager
- run ROS connection on startup and close on shutdown
- update map service to use shared rosbridge connection
- enhance orchestrator lifecycle handling for map server

## Testing
- `pip install pytest-asyncio`
- `pip install httpx`
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_684c63e990848333aa32ba253625fbe3