### PR TITLE
Improve lifecycle orchestration

### DIFF
--- a/api/app/domain/maps/service.py
+++ b/api/app/domain/maps/service.py
@@ -57,7 +57,7 @@ def list_available_maps() -> list[str]:
 
 
 async def activate_map(map_name: str) -> dict:
-    """Carga un mapa en ROS a través del servicio expuesto por el Orchestrator ('/ui/load_map')."""
+    """Carga un mapa y arranca la navegación a través del Orchestrator."""
     map_yaml_path = MAP_DIR / f"{map_name}.yaml"
     if not map_yaml_path.exists():
         logger.warning(f"Intento de activar un mapa inexistente: {map_name}")

--- a/turtlebot3-sim/orchestrator/orchestrator/main.py
+++ b/turtlebot3-sim/orchestrator/orchestrator/main.py
@@ -1,147 +1,160 @@
 import rclpy
-from rclpy.node import Node
-from rclpy.executors import MultiThreadedExecutor
-from lifecycle_msgs.srv import ChangeState
+from rclpy.lifecycle import LifecycleNode
+from lifecycle_msgs.srv import GetState, ChangeState
 from lifecycle_msgs.msg import Transition
-from nav2_msgs.srv import LoadMap
-import sys
-import os
+from std_srvs.srv import Empty
+from nav2_msgs.srv import LoadMap, ManageLifecycleNodes
+import time
 
-class Orchestrator(Node):
+
+class Orchestrator(LifecycleNode):
     def __init__(self):
         super().__init__('ui_orchestrator')
-        self.get_logger().info('Iniciando Orquestador de UI...')
 
-        # --- Clientes para Nodos de Ciclo de Vida (Lifecycle Nodes) ---
-        
-        # Cliente para cambiar el estado del map_server
-        self.map_server_change_state_client = self.create_client(ChangeState, '/map_server/change_state')
-        
-        # Puedes añadir más clientes para otros nodos de ciclo de vida aquí
-        # self.amcl_change_state_client = self.create_client(ChangeState, '/amcl/change_state')
-        # self.controller_server_change_state_client = self.create_client(ChangeState, '/controller_server/change_state')
-        # ... y así sucesivamente para todos los nodos que necesites gestionar
+        # Servicios expuestos a la UI
+        self.create_service(Empty,   'ui/start_slam', self.start_slam)
+        self.create_service(Empty,   'ui/stop_slam',  self.stop_slam)
+        self.create_service(LoadMap, 'ui/load_map',   self.load_map)
+        self.create_service(Empty,   'ui/start_nav2', self.start_nav2)
+        self.create_service(Empty,   'ui/stop_nav2',  self.stop_nav2)
 
-        # --- Servidores para Servicios ROS ---
+        # Clientes para SLAM Toolbox
+        self.slam_start_client = self.create_client(Empty, '/slam_toolbox/start')
+        self.slam_stop_client  = self.create_client(Empty, '/slam_toolbox/stop')
 
-        # Servidor para el servicio de carga de mapas (CÓDIGO CORREGIDO)
-        self.load_map_service = self.create_service(LoadMap, '/ui/load_map', self.load_map)
+        # Cliente para map_server load_map y su lifecycle
+        self.map_load_client = self.create_client(LoadMap, '/map_server/load_map')
+        self.map_server_change_state_client = self.create_client(
+            ChangeState, '/map_server/change_state')
 
-        self.get_logger().info('Orquestador de UI listo.')
+        # Lifecycle managers
+        self.map_lifecycle_client = self.create_client(
+            ManageLifecycleNodes,
+            '/lifecycle_manager_map_server/manage_nodes')
+        self.nav2_lifecycle_client = self.create_client(
+            ManageLifecycleNodes,
+            '/lifecycle_manager_navigation/manage_nodes')
 
-    def change_map_server_state(self, transition_id):
-        """
-        Solicita un cambio de estado para el nodo map_server.
-        """
-        request = ChangeState.Request()
-        request.transition.id = transition_id
-        
-        # Llamada asíncrona al servicio
-        future = self.map_server_change_state_client.call_async(request)
-        
-        # Esperamos el resultado de forma síncrona en este hilo.
-        # En una aplicación más compleja, podrías manejar esto de forma asíncrona.
-        rclpy.spin_until_future_complete(self, future, timeout_sec=5.0)
-
-        if future.result() is not None:
-            if future.result().success:
-                self.get_logger().info(f'Transición {transition_id} del map_server completada con éxito.')
-                return True
-            else:
-                self.get_logger().error(f'Falló la transición {transition_id} del map_server.')
-                return False
-        else:
-            self.get_logger().error(f'No se pudo llamar al servicio de cambio de estado del map_server para la transición {transition_id}.')
+    # ---------------------- Helper methods ----------------------
+    def _call_empty(self, client, name: str) -> bool:
+        if not client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().error(f'Service {name} unavailable')
             return False
+        fut = client.call_async(Empty.Request())
+        rclpy.spin_until_future_complete(self, fut)
+        if fut.result() is None:
+            self.get_logger().error(f'Call to {name} failed')
+            return False
+        return True
+
+    def _call_manage(self, client, name: str, command: int) -> bool:
+        if not client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().error(f'Lifecycle service {name} unavailable')
+            return False
+        req = ManageLifecycleNodes.Request(command=command)
+        fut = client.call_async(req)
+        rclpy.spin_until_future_complete(self, fut)
+        res = fut.result()
+        if res and res.success:
+            return True
+        self.get_logger().error(f'Lifecycle command {command} on {name} failed')
+        return False
+
+    def _change_map_state(self, transition_id: int) -> bool:
+        if not self.map_server_change_state_client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().error('Service /map_server/change_state unavailable')
+            return False
+        req = ChangeState.Request()
+        req.transition.id = transition_id
+        fut = self.map_server_change_state_client.call_async(req)
+        rclpy.spin_until_future_complete(self, fut)
+        res = fut.result()
+        if res and res.success:
+            time.sleep(2)
+            return True
+        self.get_logger().error(f'Map server transition {transition_id} failed')
+        return False
+
+    # ---------------------- SLAM / Nav2 control ----------------------
+    def start_slam(self, request, response):
+        # Ensure nav2 and map server are down before mapping
+        self.get_logger().info('Stopping Nav2 stack for mapping')
+        self._call_manage(
+            self.nav2_lifecycle_client,
+            '/lifecycle_manager_navigation/manage_nodes',
+            ManageLifecycleNodes.Request.SHUTDOWN)
+        self.get_logger().info('Shutting down Map Server')
+        self._call_manage(
+            self.map_lifecycle_client,
+            '/lifecycle_manager_map_server/manage_nodes',
+            ManageLifecycleNodes.Request.SHUTDOWN)
+        self.get_logger().info('Starting SLAM Toolbox')
+        self._call_empty(self.slam_start_client, '/slam_toolbox/start')
+        return response
+
+    def stop_slam(self, request, response):
+        self.get_logger().info('Stopping SLAM Toolbox')
+        self._call_empty(self.slam_stop_client, '/slam_toolbox/stop')
+        return response
 
     def load_map(self, request, response):
-        """
-        Gestiona el ciclo de vida del map_server para cargar un nuevo mapa.
-        """
-        self.get_logger().info(f'Solicitud para cargar el mapa: {request.map_url}')
+        # Switch from mapping to navigation: stop slam, start map server, start nav2
+        self.get_logger().info('Stopping SLAM Toolbox before loading map')
+        self._call_empty(self.slam_stop_client, '/slam_toolbox/stop')
 
-        # 1. Esperar a que el servicio change_state del map_server esté disponible
-        if not self.map_server_change_state_client.wait_for_service(timeout_sec=5.0):
-            self.get_logger().error('Servicio /map_server/change_state no disponible.')
-            response.result = LoadMap.Response.RESULT_UNDEFINED_FAILURE
+        self.get_logger().info('Configuring Map Server')
+        if not self._change_map_state(Transition.TRANSITION_CONFIGURE):
+            response.result = LoadMap.Response.RESULT_FAILURE
             return response
 
-        # 2. Desactivar y limpiar el map_server si ya está activo
-        # Esto asegura que podamos cargar un nuevo mapa sin conflictos.
-        self.get_logger().info('Desactivando y limpiando Map Server (si es necesario)...')
-        self.change_map_server_state(Transition.TRANSITION_DEACTIVATE)
-        self.change_map_server_state(Transition.TRANSITION_CLEANUP)
-        
-        # 3. Actualizar el parámetro `yaml_filename` del map_server
-        self.get_logger().info(f'Actualizando el parámetro yaml_filename a: {request.map_url}')
-        # NOTA: Esto requiere que el nodo `map_server` tenga el parámetro declarado y que
-        # el orquestador tenga permisos para cambiarlo.
-        # Aquí usamos un método simple, pero en un sistema real podrías usar el servicio de parámetros.
-        os.system(f'ros2 param set /map_server yaml_filename {request.map_url}')
-
-        # 4. Configurar el map_server
-        self.get_logger().info('Configurando Map Server...')
-        if not self.change_map_server_state(Transition.TRANSITION_CONFIGURE):
-            response.result = LoadMap.Response.RESULT_UNDEFINED_FAILURE
+        self.get_logger().info('Activating Map Server')
+        if not self._change_map_state(Transition.TRANSITION_ACTIVATE):
+            response.result = LoadMap.Response.RESULT_FAILURE
             return response
 
-        # 5. Activar el map_server para que cargue el mapa y empiece a publicarlo
-        self.get_logger().info('Activando Map Server...')
-        if not self.change_map_server_state(Transition.TRANSITION_ACTIVATE):
-            response.result = LoadMap.Response.RESULT_UNDEFINED_FAILURE
-            return response
-
-<<<<<<< HEAD
-        self.get_logger().info(f'Mapa {request.map_url} cargado con éxito.')
-        response.result = LoadMap.Response.RESULT_SUCCESS
-=======
-        self.get_logger().info(f"Llamando a /map_server/load_map con URL: {request.map_url}")
+        self.get_logger().info(f'Calling load_map with URL: {request.map_url}')
         if not self.map_load_client.wait_for_service(timeout_sec=5.0):
-            self.get_logger().error('Servicio /map_server/load_map no disponible tras la activación.')
-            response.result = LoadMap.Response.RESULT_UNDEFINED_FAILURE
+            self.get_logger().error('Service /map_server/load_map unavailable')
+            response.result = LoadMap.Response.RESULT_FAILURE
             return response
-
         fut = self.map_load_client.call_async(request)
         rclpy.spin_until_future_complete(self, fut)
         result = fut.result()
-
-        if result is None:
-            self.get_logger().error('La llamada a LoadMap falló (timeout o error interno).')
-            response.result = LoadMap.Response.RESULT_UNDEFINED_FAILURE
+        if result is None or result.result != LoadMap.Response.RESULT_SUCCESS:
+            self.get_logger().error('LoadMap call failed')
+            response.result = LoadMap.Response.RESULT_FAILURE
             return response
 
-        self.get_logger().info(f'Respuesta de LoadMap: {result}')
+        self.get_logger().info('Starting Nav2 stack after map load')
+        self._call_manage(
+            self.nav2_lifecycle_client,
+            '/lifecycle_manager_navigation/manage_nodes',
+            ManageLifecycleNodes.Request.STARTUP)
         return result
 
     def start_nav2(self, request, response):
-        # Startup the full Nav2 stack
         self.get_logger().info('Starting Nav2 stack')
-        self.call_manage_lifecycle(
+        self._call_manage(
             self.nav2_lifecycle_client,
             '/lifecycle_manager_navigation/manage_nodes',
-            ManageLifecycleNodes.Request.STARTUP
-        )
->>>>>>> 65d2d478e59f4ed29e0e0d617099e99751464efa
+            ManageLifecycleNodes.Request.STARTUP)
         return response
+
+    def stop_nav2(self, request, response):
+        self.get_logger().info('Shutting down Nav2 stack')
+        self._call_manage(
+            self.nav2_lifecycle_client,
+            '/lifecycle_manager_navigation/manage_nodes',
+            ManageLifecycleNodes.Request.SHUTDOWN)
+        return response
+
 
 def main(args=None):
     rclpy.init(args=args)
-    
-    try:
-        node = Orchestrator()
-        # Usamos un ejecutor Multi-Hilos para que las llamadas a servicios
-        # no bloqueen el procesamiento de otros callbacks.
-        executor = MultiThreadedExecutor()
-        executor.add_node(node)
-        
-        try:
-            executor.spin()
-        finally:
-            executor.shutdown()
-            node.destroy_node()
-            
-    finally:
-        rclpy.shutdown()
+    node = Orchestrator()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/ui_web/src/components/NewMapButton.jsx
+++ b/ui_web/src/components/NewMapButton.jsx
@@ -4,21 +4,18 @@ import ros from '../services/rosService';
 export default function NewMapButton() {
   const [busy, setBusy] = useState(false);
 
-    // Iniciar borrando el mapa y activando modo interactivo
-    const startMapping = async () => {
+  // Solicita al Orchestrator activar el modo mapeo
+  const startMapping = async () => {
     setBusy(true);
     try {
-        // 1. Clear (descarta mapas previos)
-        await ros.callService('/slam_toolbox/clear_changes', 'slam_toolbox/srv/Clear');
-        // 2. (Opcional) toggle_interactive para reiniciar pose graph
-        await ros.callService('/slam_toolbox/toggle_interactive_mode', 'slam_toolbox/srv/ToggleInteractive');
-        alert('SLAM listo: conduce el robot para mapear.');
+      await ros.callService('/ui/start_slam', 'std_srvs/srv/Empty');
+      alert('SLAM listo: conduce el robot para mapear.');
     } catch (e) {
-        alert('Error al controlar SLAM:\n' + e);
+      alert('Error al iniciar SLAM:\n' + e);
     } finally {
-        setBusy(false);
+      setBusy(false);
     }
-    };
+  };
 
 
   return (


### PR DESCRIPTION
## Summary
- reimplement orchestrator node as a Lifecycle manager
- call orchestrator to start mapping from NewMapButton
- document map activation service

## Testing
- `pip install -r api/requirements.txt`
- `PYTHONPATH=api pytest -q` *(fails: ServerSelectionTimeoutError connecting to mongodb)*

------
https://chatgpt.com/codex/tasks/task_e_6851d3afbc808333919f43fab77ebb6c