### PR TITLE
Fix lifecycle calls for SLAM and map server

### DIFF
--- a/turtlebot3-sim/entrypoint.sh
+++ b/turtlebot3-sim/entrypoint.sh
@@ -18,7 +18,11 @@ ros2 run nav2_map_server map_server \
   --ros-args \
     -p use_sim_time:=True &
 
-# 4) Iniciar lifecycle manager del Map Server, sin autostart
+# 4) Iniciar SLAM Toolbox en modo async
+ros2 launch slam_toolbox online_async_launch.py \
+  use_sim_time:=True &
+
+# 5) Iniciar lifecycle manager del Map Server, sin autostart
 echo "--- [DEBUG] Iniciando lifecycle_manager_map_server (autostart=False) ---"
 ros2 run nav2_lifecycle_manager lifecycle_manager \
   --ros-args \
@@ -27,15 +31,25 @@ ros2 run nav2_lifecycle_manager lifecycle_manager \
     -p node_names:="['map_server']" \
     -r __node:=lifecycle_manager_map_server &
 
-sleep 2
+# 6) Iniciar lifecycle manager para slam_toolbox
+echo "--- [DEBUG] Iniciando lifecycle_manager_slam_toolbox (autostart=False) ---"
+ros2 run nav2_lifecycle_manager lifecycle_manager \
+  --ros-args \
+    -p use_sim_time:=True \
+    -p autostart:=False \
+    -p node_names:="['slam_toolbox']" \
+    -r __node:=lifecycle_manager_slam_toolbox &
 
-# 5) Arrancar rosbridge_websocket en background
+# 7) Esperar a que los nodos arranquen
+sleep 5
+
+# 8) Arrancar rosbridge_websocket en background
 echo "--- [DEBUG] Iniciando rosbridge_websocket en puerto 9090 ---"
 ros2 launch rosbridge_server rosbridge_websocket_launch.xml port:=9090 &
 
-# 6) Esperar a que tome el puerto
+# 9) Esperar a que tome el puerto
 sleep 5
 
-# 7) Ejecutar Orchestrator
+# 10) Ejecutar Orchestrator
 echo "--- [DEBUG] Ejecutando Orchestrator ---"
 exec /ros2_ws/install/bin/orchestrator "$@"

--- a/turtlebot3-sim/orchestrator/orchestrator/main.py
+++ b/turtlebot3-sim/orchestrator/orchestrator/main.py
@@ -3,6 +3,8 @@ from rclpy.lifecycle import LifecycleNode
 
 from std_srvs.srv import Empty
 from nav2_msgs.srv import LoadMap, ManageLifecycleNodes
+from lifecycle_msgs.srv import ChangeState
+from lifecycle_msgs.msg import Transition
 import os
 
 
@@ -17,11 +19,10 @@ class Orchestrator(LifecycleNode):
         self.create_service(Empty, "ui/start_nav2", self.start_nav2)
         self.create_service(Empty, "ui/stop_nav2", self.stop_nav2)
 
-        # Clientes para SLAM Toolbox
-        self.slam_start_client = self.create_client(
-            Empty, "/slam_toolbox/start"
+        # Lifecycle clients for SLAM Toolbox and Map Server
+        self.slam_lifecycle_client = self.create_client(
+            ChangeState, "/lifecycle_manager_slam_toolbox/change_state"
         )
-        self.slam_stop_client = self.create_client(Empty, "/slam_toolbox/stop")
 
         # Cliente para map_server y su servicio load_map
         self.map_load_client = self.create_client(
@@ -30,23 +31,28 @@ class Orchestrator(LifecycleNode):
 
         # Lifecycle managers
         self.map_lifecycle_client = self.create_client(
-            ManageLifecycleNodes, "/lifecycle_manager_map_server/manage_nodes"
+            ChangeState, "/lifecycle_manager_map_server/change_state"
         )
         self.nav2_lifecycle_client = self.create_client(
             ManageLifecycleNodes, "/lifecycle_manager_navigation/manage_nodes"
         )
 
     # ---------------------- Helper methods ----------------------
-    def _call_empty(self, client, name: str) -> bool:
+    def _call_change_state(self, client, name: str, transition: int) -> bool:
         if not client.wait_for_service(timeout_sec=5.0):
             self.get_logger().error(f"Service {name} unavailable")
             return False
-        fut = client.call_async(Empty.Request())
+        req = ChangeState.Request()
+        req.transition.id = transition
+        fut = client.call_async(req)
         rclpy.spin_until_future_complete(self, fut)
-        if fut.result() is None:
-            self.get_logger().error(f"Call to {name} failed")
-            return False
-        return True
+        res = fut.result()
+        if res and res.success:
+            return True
+        self.get_logger().error(
+            f"Transition {transition} on {name} failed"
+        )
+        return False
 
     def _call_manage(self, client, name: str, command: int) -> bool:
         if not client.wait_for_service(timeout_sec=5.0):
@@ -65,39 +71,57 @@ class Orchestrator(LifecycleNode):
 
     # ---------------------- SLAM / Nav2 control ----------------------
     def start_slam(self, request, response):
-        # Ensure nav2 and map server are down before mapping
+        # Ensure nav2 stack is down before mapping
         self.get_logger().info("Stopping Nav2 stack for mapping")
         self._call_manage(
             self.nav2_lifecycle_client,
             "/lifecycle_manager_navigation/manage_nodes",
             ManageLifecycleNodes.Request.SHUTDOWN,
         )
-        self.get_logger().info("Resetting Map Server")
-        self._call_manage(
+        self.get_logger().info("Cleaning up Map Server")
+        self._call_change_state(
             self.map_lifecycle_client,
-            "/lifecycle_manager_map_server/manage_nodes",
-            ManageLifecycleNodes.Request.RESET,
+            "/lifecycle_manager_map_server/change_state",
+            Transition.TRANSITION_CLEANUP,
         )
-        self.get_logger().info("Starting SLAM Toolbox")
-        self._call_empty(self.slam_start_client, "/slam_toolbox/start")
+        self.get_logger().info("Configuring SLAM Toolbox")
+        self._call_change_state(
+            self.slam_lifecycle_client,
+            "/lifecycle_manager_slam_toolbox/change_state",
+            Transition.TRANSITION_CONFIGURE,
+        )
+        self.get_logger().info("Activating SLAM Toolbox")
+        self._call_change_state(
+            self.slam_lifecycle_client,
+            "/lifecycle_manager_slam_toolbox/change_state",
+            Transition.TRANSITION_ACTIVATE,
+        )
         return response
 
     def stop_slam(self, request, response):
-        self.get_logger().info("Stopping SLAM Toolbox")
-        self._call_empty(self.slam_stop_client, "/slam_toolbox/stop")
+        self.get_logger().info("Deactivating SLAM Toolbox")
+        self._call_change_state(
+            self.slam_lifecycle_client,
+            "/lifecycle_manager_slam_toolbox/change_state",
+            Transition.TRANSITION_DEACTIVATE,
+        )
         return response
 
     def load_map(self, request, response):
-        # Switch from mapping to navigation: stop SLAM, start map server, load map, start Nav2
-        self.get_logger().info("Stopping SLAM Toolbox before loading map")
-        self._call_empty(self.slam_stop_client, "/slam_toolbox/stop")
+        # Switch from mapping to navigation: stop SLAM, reset map server, load map, start Nav2
+        self.get_logger().info("Deactivating SLAM Toolbox before loading map")
+        self._call_change_state(
+            self.slam_lifecycle_client,
+            "/lifecycle_manager_slam_toolbox/change_state",
+            Transition.TRANSITION_DEACTIVATE,
+        )
 
         # Reset map server to ensure fresh configuration
-        self.get_logger().info("Resetting Map Server")
-        self._call_manage(
+        self.get_logger().info("Cleaning up Map Server")
+        self._call_change_state(
             self.map_lifecycle_client,
-            "/lifecycle_manager_map_server/manage_nodes",
-            ManageLifecycleNodes.Request.RESET,
+            "/lifecycle_manager_map_server/change_state",
+            Transition.TRANSITION_CLEANUP,
         )
 
         # Set map YAML file for next startup
@@ -105,11 +129,16 @@ class Orchestrator(LifecycleNode):
             f"ros2 param set /map_server yaml_filename {request.map_url}"
         )
 
-        self.get_logger().info("Starting Map Server")
-        self._call_manage(
+        self.get_logger().info("Configuring Map Server")
+        self._call_change_state(
             self.map_lifecycle_client,
-            "/lifecycle_manager_map_server/manage_nodes",
-            ManageLifecycleNodes.Request.STARTUP,
+            "/lifecycle_manager_map_server/change_state",
+            Transition.TRANSITION_CONFIGURE,
+        )
+        self._call_change_state(
+            self.map_lifecycle_client,
+            "/lifecycle_manager_map_server/change_state",
+            Transition.TRANSITION_ACTIVATE,
         )
 
         self.get_logger().info(f"Loading map via service: {request.map_url}")


### PR DESCRIPTION
## Summary
- use `ChangeState` clients for slam_toolbox and map_server
- launch slam_toolbox and its lifecycle manager from entrypoint
- cleanup map server and configure/activate via lifecycle manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6855ea20c7208333ad0007303f34bbab