### PR TITLE
Add dev Docker overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# AMR Development Workflow
+
+Build the docker images once and then use compose overrides for live reload during development.
+
+## Build base images
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.api.yml build
+# build the ROS image
+docker compose -f turtlebot3-sim/docker-compose.yml build
+```
+
+## Start development stack
+
+```bash
+# UI + API with live reload
+docker compose up
+
+# Simulation using the dev override to mount the orchestrator
+docker compose -f turtlebot3-sim/docker-compose.yml -f turtlebot3-sim/docker-compose.dev.yml up
+```
+
+The overrides run the FastAPI server with `uvicorn --reload` and mount the
+`orchestrator` package into the ROS workspace. The dev compose for the
+simulation executes `colcon build` on start so any Python changes are
+recompiled automatically.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,3 +13,14 @@ services:
       - VITE_API_URL=http://localhost:5000
     networks:
       - ros_net
+
+  api:
+    build: null
+    image: python:3.11-slim
+    command: uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    working_dir: /app
+    volumes:
+      - ./api:/app
+      - ./maps:/maps
+    networks:
+      - ros_net

--- a/turtlebot3-sim/docker-compose.dev.yml
+++ b/turtlebot3-sim/docker-compose.dev.yml
@@ -1,0 +1,11 @@
+services:
+  tb3_sim:
+    build: null
+    image: turtlebot3-sim:latest
+    volumes:
+      - ../maps:/root/maps
+      - /run/desktop/mnt/host/wslg/.X11-unix:/tmp/.X11-unix
+      - /run/desktop/mnt/host/wslg:/mnt/wslg
+      - ./orchestrator:/ros2_ws/src/orchestrator
+    entrypoint: /bin/bash
+    command: -c "colcon build --merge-install && exec /entrypoint.sh"

--- a/turtlebot3-sim/docker-compose.yml
+++ b/turtlebot3-sim/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: turtlebot3-sim:latest
     container_name: tb3_sim
     environment: *wslg-env
     networks: [ros_net]


### PR DESCRIPTION
## Summary
- add API override for running via uvicorn with reload
- tag turtlebot3-sim image and add dev compose for mounting orchestrator
- document development workflow in new README

## Testing
- `pip install -q -r api/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError and MongoDB connection issues)*

------
https://chatgpt.com/codex/tasks/task_e_686498eb5f508333b887e1708a87e137