### PR TITLE
Enable map interactions for pose, goals and points

### DIFF
--- a/ui_web/src/components/Map.jsx
+++ b/ui_web/src/components/Map.jsx
@@ -2,8 +2,11 @@
 import { MapContainer, useMap } from 'react-leaflet';
 import { useEffect, useRef, useState } from 'react';
 import L from 'leaflet';
+import ROSLIB from 'roslib';
 import ros from '../services/rosService';
 import { FOOTPRINT } from '../utils/constants';
+import { useData } from '../context/DataContext';
+import { PointsAPI } from '../services/api';
 import 'leaflet/dist/leaflet.css';
 
 /* CRS.Simple = plano en metros.
@@ -17,10 +20,33 @@ export default function Map() {
   const scanLayer   = useRef(L.layerGroup());   // nube de puntos
   const canvas      = useRef(document.createElement('canvas'));
   const poseRef     = useRef({ x: 0, y: 0, yaw: 0 });
+  const initPubRef  = useRef(null);
+  const goalPubRef  = useRef(null);
 
   const [pose, setPose] = useState({ x: 0, y: 0, yaw: 0 });
   const [gridInfo, setGridInfo] = useState(null); // info de /map
   const scanSubRef = useRef(null); // <-- NUEVO
+  const [mode, setMode] = useState(null); // initial | goal | point
+  const { selectedMap, setPoints } = useData();
+
+  // Publishers for initial pose and goal pose
+  useEffect(() => {
+    initPubRef.current = ros.advertise(
+      '/initialpose',
+      'geometry_msgs/PoseWithCovarianceStamped'
+    );
+    goalPubRef.current = ros.advertise(
+      '/goal_pose',
+      'geometry_msgs/PoseStamped'
+    );
+    // Explicitly advertise
+    initPubRef.current.advertise();
+    goalPubRef.current.advertise();
+    return () => {
+      initPubRef.current.unadvertise();
+      goalPubRef.current.unadvertise();
+    };
+  }, []);
 
   /* ───────── 1.  /tf  →  pose ─────────────────────────────────── */
   useEffect(() => {
@@ -146,6 +172,13 @@ export default function Map() {
    ];
   };
 
+  const quatFromYaw = yaw => ({
+    x: 0,
+    y: 0,
+    z: Math.sin(yaw / 2),
+    w: Math.cos(yaw / 2)
+  });
+
   /* ───────── inicia mapa ───────────────────────────────────────── */
   function MapInit() {
    const map = useMap();
@@ -153,16 +186,91 @@ export default function Map() {
    return null;
   }
 
+  async function onMapClick(e) {
+    const { lat, lng } = e.latlng;
+    if (mode === 'initial' && initPubRef.current) {
+      const yaw = parseFloat(prompt('Yaw (grados)', '0')) * Math.PI / 180 || 0;
+      const msg = new ROSLIB.Message({
+        header: { frame_id: 'map' },
+        pose: {
+          pose: {
+            position: { x: lng, y: lat, z: 0 },
+            orientation: quatFromYaw(yaw)
+          },
+          covariance: Array(36).fill(0)
+        }
+      });
+      initPubRef.current.publish(msg);
+      setMode(null);
+    } else if (mode === 'goal' && goalPubRef.current) {
+      const yaw = parseFloat(prompt('Yaw (grados)', '0')) * Math.PI / 180 || 0;
+      const msg = new ROSLIB.Message({
+        header: { frame_id: 'map' },
+        pose: {
+          position: { x: lng, y: lat, z: 0 },
+          orientation: quatFromYaw(yaw)
+        }
+      });
+      goalPubRef.current.publish(msg);
+      setMode(null);
+    } else if (mode === 'point' && selectedMap) {
+      const name = prompt('Nombre del punto');
+      if (!name) return;
+      const yaw = parseFloat(prompt('Yaw (grados)', '0')) * Math.PI / 180 || 0;
+      await PointsAPI.create(
+        {
+          name,
+          type: 'way',
+          map_id: selectedMap,
+          target: {
+            x: lng,
+            y: lat,
+            z: 0,
+            q1: 0,
+            q2: 0,
+            q3: quatFromYaw(yaw).z,
+            q4: quatFromYaw(yaw).w
+          }
+        }
+      );
+      setPoints(await PointsAPI.list(selectedMap));
+      setMode(null);
+    }
+  }
+
   return (
-   <MapContainer
-    crs={L.CRS.Simple}
-    center={[0, 0]}
-    zoom={0}
-    minZoom={-4}
-    style={{ height: '26rem', width: '100%' }}
-    scrollWheelZoom
-   >
-    <MapInit />
-   </MapContainer>
-  );
-}
+    <div className="relative">
+      <MapContainer
+        crs={L.CRS.Simple}
+        center={[0, 0]}
+        zoom={0}
+        minZoom={-4}
+        style={{ height: '26rem', width: '100%' }}
+        scrollWheelZoom
+        onClick={onMapClick}
+      >
+        <MapInit />
+      </MapContainer>
+      <div className="absolute top-2 left-2 z-10 flex gap-2">
+        <button
+          className={`btn ${mode === 'initial' ? 'bg-blue-500 text-white' : 'bg-white'}`}
+          onClick={() => setMode(mode === 'initial' ? null : 'initial')}
+        >
+          Pose inicial
+        </button>
+        <button
+          className={`btn ${mode === 'goal' ? 'bg-blue-500 text-white' : 'bg-white'}`}
+          onClick={() => setMode(mode === 'goal' ? null : 'goal')}
+        >
+          Objetivo
+        </button>
+        <button
+          className={`btn ${mode === 'point' ? 'bg-blue-500 text-white' : 'bg-white'}`}
+          onClick={() => setMode(mode === 'point' ? null : 'point')}
+        >
+          Nuevo punto
+        </button>
+      </div>
+    </div>
+  );}
+


### PR DESCRIPTION
## Summary
- add ROS publishers for `/initialpose` and `/goal_pose`
- add "Pose inicial", "Objetivo" and "Nuevo punto" buttons to map
- allow setting initial pose, sending a goal and saving a new point by clicking on the map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'beanie')*

------
https://chatgpt.com/codex/tasks/task_e_686d845e55088333b6b2545c98cd280b