### PR TITLE
Start Nav2 automatically

### DIFF
--- a/turtlebot3-sim/orchestrator/orchestrator/main.py
+++ b/turtlebot3-sim/orchestrator/orchestrator/main.py
@@ -54,6 +54,14 @@ class Orchestrator(LifecycleNode):
             ManageLifecycleNodes, "/lifecycle_manager_navigation/manage_nodes", callback_group=self.cb_group
         )
 
+        # Arrancar la pila de navegación nada más inicializar el nodo
+        self.get_logger().info("Starting Nav2 stack on startup")
+        self._call_manage(
+            self.nav2_lifecycle_client,
+            "/lifecycle_manager_navigation/manage_nodes",
+            ManageLifecycleNodes.Request.STARTUP,
+        )
+
 
     # ---------------------- Helper methods ----------------------
     def _call_change_state(self, client, name: str, transition: int) -> bool:


### PR DESCRIPTION
## Summary
- start the Nav2 stack as soon as the orchestrator node starts

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q` *(fails: ServerSelectionTimeoutError connecting to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_6872604e846c8333ad249bef363582ef