### PR TITLE
Fix initial pose TF error by enabling sim time

### DIFF
--- a/turtlebot3-sim/orchestrator/launch/system_launch.py
+++ b/turtlebot3-sim/orchestrator/launch/system_launch.py
@@ -42,7 +42,8 @@ def generate_launch_description():
         package='orchestrator',
         executable='orchestrator',
         name='ui_orchestrator',
-        output='screen'
+        output='screen',
+        parameters=[{'use_sim_time': True}]
     )
 
     declare_world = DeclareLaunchArgument(


### PR DESCRIPTION
## Summary
- orchestrator: run with `use_sim_time` so the initial pose timestamp matches the simulation clock

## Testing
- `pip install -r api/requirements.txt`
- `PYTHONPATH=./api pytest -q` *(fails: ModuleNotFoundError / DB connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687274466434833399a3c7f8e45724f4