### PR TITLE
Fix initial pose TF error by honoring CLI params

### DIFF
--- a/turtlebot3-sim/orchestrator/launch/system_launch.py
+++ b/turtlebot3-sim/orchestrator/launch/system_launch.py
@@ -42,7 +42,8 @@ def generate_launch_description():
         package='orchestrator',
         executable='orchestrator',
         name='ui_orchestrator',
-        output='screen'
+        output='screen',
+        parameters=[{'use_sim_time': True}]
     )
 
     declare_world = DeclareLaunchArgument(

--- a/turtlebot3-sim/orchestrator/orchestrator/main.py
+++ b/turtlebot3-sim/orchestrator/orchestrator/main.py
@@ -18,7 +18,11 @@ DEFAULT_MAP = "/root/maps/Turtle1.yaml"
 
 class Orchestrator(LifecycleNode):
     def __init__(self):
-        super().__init__("ui_orchestrator")
+        # Automatically declare parameters passed via CLI/launch, e.g. use_sim_time
+        super().__init__(
+            "ui_orchestrator",
+            automatically_declare_parameters_from_overrides=True,
+        )
 
         # Grupo reentrante para evitar deadlocks en callbacks anidados
         self.cb_group = ReentrantCallbackGroup()


### PR DESCRIPTION
## Summary
- orchestrator: declare parameters from CLI so `use_sim_time` works

## Testing
- `pip install -r api/requirements.txt`
- `PYTHONPATH=./api pytest -q` *(fails: ServerSelectionTimeoutError connecting to MongoDB)*


------
https://chatgpt.com/codex/tasks/task_e_687274466434833399a3c7f8e45724f4